### PR TITLE
Updating project to run on Dart 1.4

### DIFF
--- a/client/lib/transformer.dart
+++ b/client/lib/transformer.dart
@@ -17,8 +17,9 @@ class GoogleWebmasterVerifier extends Transformer {
 
   GoogleWebmasterVerifier.asPlugin();
 
-  Future<bool> isPrimary(Asset asset) {
-    var contains = asset.id.path.startsWith('asset/config.yaml');
+  Future<bool> isPrimary(assetOrId) {
+    var id = assetOrId is Asset ? assetOrId.id : assetOrId;
+    var contains = id.path.startsWith('asset/config.yaml');
     return new Future.value(contains);
   }
 
@@ -60,8 +61,10 @@ class AnalyticsTransformer extends Transformer {
 
   AnalyticsTransformer.asPlugin();
 
-  Future<bool> isPrimary(Asset asset) =>
-      new Future.value(asset.id.path == _INDEX_FILE_PATH);
+  Future<bool> isPrimary(assetOrId) {
+    var id = assetOrId is Asset ? assetOrId.id : assetOrId;
+    return new Future.value(id.path == _INDEX_FILE_PATH);
+  }
 
   Future apply(Transform transform) {
     var configAssetId = new AssetId(_PACKAGE_NAME, _CONFIG_PATH);

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -12,7 +12,7 @@ packages:
   barback:
     description: barback
     source: hosted
-    version: "0.12.0"
+    version: "0.13.0"
   browser:
     description: browser
     source: hosted
@@ -20,7 +20,7 @@ packages:
   code_transformers:
     description: code_transformers
     source: hosted
-    version: "0.1.1+1"
+    version: "0.1.3"
   collection:
     description: collection
     source: hosted
@@ -44,7 +44,7 @@ packages:
   observe:
     description: observe
     source: hosted
-    version: "0.10.0-pre.3"
+    version: "0.10.0-pre.4"
   path:
     description: path
     source: hosted
@@ -52,7 +52,7 @@ packages:
   polymer:
     description: polymer
     source: hosted
-    version: "0.10.0-pre.8"
+    version: "0.10.0-pre.9"
   polymer_expressions:
     description: polymer_expressions
     source: hosted
@@ -60,7 +60,7 @@ packages:
   smoke:
     description: smoke
     source: hosted
-    version: "0.1.0-pre.2"
+    version: "0.1.0-pre.3"
   source_maps:
     description: source_maps
     source: hosted

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
   polymer_expressions: '>=0.9.1 <0.10.0'
   yaml: '>=0.9.0 <0.10.0'
 dev_dependencies:
-  barback: '>=0.11.0 <0.13.0'
+  barback: '>=0.11.0 <0.14.0'
   unittest: '>=0.10.0 <0.11.0'
 transformers:
 - polymer:


### PR DESCRIPTION
This requires updating barback dependency to 0.13.0, following steps from https://groups.google.com/a/dartlang.org/forum/#!topic/misc/579fz2SRnLA to maintain compatibility with Dart 1.3.
