### PR TITLE
Make the ellipsis more visible

### DIFF
--- a/client/lib/components/class.dart
+++ b/client/lib/components/class.dart
@@ -110,10 +110,13 @@ class ClassElement extends MemberElement {
     }
     if (subclasses.length <= MAX_SUBCLASSES_TO_SHOW) return;
     var ellipsis = new AnchorElement()
-      ..classes = ["btn", "btn-link", "btn-xs"]
+      ..classes = ["btn-link"]
       ..id = "subclass-button"
       ..text = "..."
       ..onClick.listen((event) => showSubclass(null, null, null));
+    p.append(new SpanElement()
+               ..text = ', '
+               ..id = 'subclass-hidden');
     p.append(ellipsis);
     makeLinks(subclasses.skip(MAX_SUBCLASSES_TO_SHOW), hidden: true)
         .forEach(p.append);


### PR DESCRIPTION
This PR fixes [dartbug 16715](https://code.google.com/p/dart/issues/detail?id=16715). I add a comma before the ellipsis, separating it from the class preceding, and I remove the `btn` and `btn-xs` classes, which make it bigger, and keep it vertically positioned correctly with the class names preceding. Verified in Chrome Dev Tools.
